### PR TITLE
Exponential backoff on HTTP 429

### DIFF
--- a/http.go
+++ b/http.go
@@ -55,11 +55,8 @@ func (r *RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 			return resp, nil
 		}
 
-		baseWait := 9 * time.Second
-		backoff := time.Duration(math.Pow(2, float64(i))) * time.Second
-		wait := baseWait + backoff
-
-		time.Sleep(wait)
+		backoff := time.Duration(math.Pow(1.5, float64(i))) * time.Second
+		time.Sleep(backoff)
 	}
 
 	return resp, err

--- a/http.go
+++ b/http.go
@@ -1,16 +1,23 @@
 package hjem
 
-import "net/http"
+import (
+	"math"
+	"net/http"
+	"time"
+)
 
 var DefaultClient http.Client
 
 func init() {
 	DefaultClient = http.Client{
-		Transport: &DefaultHeadersTripper{
-			next: http.DefaultTransport,
-			headers: map[string]string{
-				"User-Agent": "tpanum/hjem (github.com/tpanum/hjem)",
+		Transport: &RetryRoundTripper{
+			next: &DefaultHeadersTripper{
+				next: http.DefaultTransport,
+				headers: map[string]string{
+					"User-Agent": "tpanum/hjem (github.com/tpanum/hjem)",
+				},
 			},
+			maxRetries: 5,
 		},
 	}
 }
@@ -26,4 +33,34 @@ func (t *DefaultHeadersTripper) RoundTrip(req *http.Request) (*http.Response, er
 	}
 
 	return t.next.RoundTrip(req)
+}
+
+type RetryRoundTripper struct {
+	next       http.RoundTripper
+	maxRetries int
+}
+
+func (r *RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+
+	for i := 0; i <= r.maxRetries; i++ {
+		resp, err = r.next.RoundTrip(req)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != 429 {
+			return resp, nil
+		}
+
+		baseWait := 9 * time.Second
+		backoff := time.Duration(math.Pow(2, float64(i))) * time.Second
+		wait := baseWait + backoff
+
+		time.Sleep(wait)
+	}
+
+	return resp, err
 }


### PR DESCRIPTION
Fixes #4 

Adds a round-tripper implementing retry logic with exponential backoff on HTTP 429 responses.